### PR TITLE
[optimize] JuiceFS meta URL uses PostgreSQL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Polyfiller is kindly supported by [JetBrains](https://www.jetbrains.com/?from=Po
 - [FAQ](#faq)
   - [What's the difference from polyfill.io](#whats-the-difference-from-polyfillio)
   - [Hosting](#hosting)
+    - [Docker](#docker)
+      - [Simple container](#simple-container)
+      - [Composed services with Object Storage](#composed-services-with-object-storage)
+        - [1. Manual deployment](#1-manual-deployment)
+        - [2. Automatic deployment](#2-automatic-deployment)
 - [Logo](#logo)
 - [License](#license)
   - [Feature names](#feature-names)
@@ -386,7 +391,7 @@ sudo docker plugin install juicedata/juicefs
 
 ###### 1. Manual deployment
 
-1. Write [JuiceFS environment variables](https://juicefs.com/docs/community/juicefs_on_docker/#using-docker-compose) into `.env` file in the Project Root folder:
+1. Write [JuiceFS object storage variables](https://juicefs.com/docs/community/reference/how_to_set_up_object_storage/) into `.env` file in the Project Root folder:
 
 ```ini
 STORAGE_TYPE =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@ volumes:
     driver: juicedata/juicefs
     driver_opts:
       name: polyfill-cache
-      metaurl: sqlite3://polyfill-cache.db
+      # metaurl: sqlite3://polyfill-cache.db
+      metaurl: postgres://postgres:${ADMIN_JWT_SECRET}@postgres-server:5432/juicefs
       storage: ${STORAGE_TYPE}
       bucket: ${BUCKET}
       access-key: ${ACCESS_KEY}
@@ -16,6 +17,8 @@ networks:
 
 services:
   api-service:
+    depends_on:
+      - postgres-server
     image: polyfiller/api-service
     environment:
       - NODE_ENV=production
@@ -37,6 +40,22 @@ services:
       driver: json-file
       options:
         max-size: 10m
+  
+  postgres-server:
+    image: postgres:14.11
+    environment:
+      - POSTGRES_PASSWORD=${ADMIN_JWT_SECRET}
+    volumes:
+      - polyfill-cache:/var/lib/postgresql/data/
+    networks:
+      - polyfiller
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 3s
+      retries: 5
+    labels:
+      - autoheal=true
+    restart: always
 
   autoheal:
     image: willfarrell/autoheal:1.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=${META DATA_PASSWORD}
     volumes:
-      - polyfill-cache:/var/lib/postgresql/data/
+      - ./data:/var/lib/postgresql/data/
     networks:
       - polyfiller
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ volumes:
     driver: juicedata/juicefs
     driver_opts:
       name: polyfill-cache
-      # metaurl: sqlite3://polyfill-cache.db
       metaurl: postgres://postgres:${METADATA_PASSWORD}@meta-server:5432/juicefs
       storage: ${STORAGE_TYPE}
       bucket: ${BUCKET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
     driver_opts:
       name: polyfill-cache
       # metaurl: sqlite3://polyfill-cache.db
-      metaurl: postgres://postgres:${META DATA_PASSWORD}@meta-server:5432/juicefs
+      metaurl: postgres://postgres:${METADATA_PASSWORD}@meta-server:5432/juicefs
       storage: ${STORAGE_TYPE}
       bucket: ${BUCKET}
       access-key: ${ACCESS_KEY}
@@ -44,7 +44,7 @@ services:
   meta-server:
     image: postgres
     environment:
-      - POSTGRES_PASSWORD=${META DATA_PASSWORD}
+      - POSTGRES_PASSWORD=${METADATA_PASSWORD}
     volumes:
       - ./data:/var/lib/postgresql/data/
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
   
   meta-server:
     image: postgres
+    user: postgres
     environment:
       - POSTGRES_PASSWORD=${METADATA_PASSWORD}
     volumes:
@@ -49,7 +50,7 @@ services:
     networks:
       - polyfiller
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready  -U postgres" ]
       interval: 3s
       retries: 5
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
     driver_opts:
       name: polyfill-cache
       # metaurl: sqlite3://polyfill-cache.db
-      metaurl: postgres://postgres:${ADMIN_JWT_SECRET}@postgres-server:5432/juicefs
+      metaurl: postgres://postgres:${META DATA_PASSWORD}@meta-server:5432/juicefs
       storage: ${STORAGE_TYPE}
       bucket: ${BUCKET}
       access-key: ${ACCESS_KEY}
@@ -18,7 +18,7 @@ networks:
 services:
   api-service:
     depends_on:
-      - postgres-server
+      - meta-server
     image: polyfiller/api-service
     environment:
       - NODE_ENV=production
@@ -41,10 +41,10 @@ services:
       options:
         max-size: 10m
   
-  postgres-server:
-    image: postgres:14.11
+  meta-server:
+    image: postgres
     environment:
-      - POSTGRES_PASSWORD=${ADMIN_JWT_SECRET}
+      - POSTGRES_PASSWORD=${META DATA_PASSWORD}
     volumes:
       - polyfill-cache:/var/lib/postgresql/data/
     networks:


### PR DESCRIPTION
1. [optimize] JuiceFS meta URL uses PostgreSQL (closed #2)
2. [fix] Docker deploying document 